### PR TITLE
Fix- automatic user_id injection for capabilities that require authen…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ site/
 # Cloudflare tunnel binary
 cloudflared
 coverage_services/
+
+# AI Assistant Rules
+!.cursorrules
+/.windsurf/

--- a/packages/api/src/maverick_api/routers/v1/capabilities.py
+++ b/packages/api/src/maverick_api/routers/v1/capabilities.py
@@ -205,6 +205,14 @@ async def get_capability(capability_id: str) -> CapabilityDetail:
         }
         if cap.api
         else None,
+        ui={
+            "expose": cap.ui.expose,
+            "component": cap.ui.expose,
+            "route": cap.ui.route,
+            "menu_group": cap.ui.menu_group,
+            "manu_label": cap.ui.menu_label,
+            "menu_order": cap.ui.menu_order,
+        },
         deprecated=cap.deprecated,
         tags=cap.tags,
     )

--- a/packages/data/src/maverick_data/repositories/portfolio_repository.py
+++ b/packages/data/src/maverick_data/repositories/portfolio_repository.py
@@ -16,7 +16,7 @@ from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from maverick_data.models import UserPortfolio, PortfolioPosition
-from maverick_data.session import get_async_db
+from maverick_data.session import get_async_session
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +49,9 @@ class PortfolioRepository:
         """Get database session."""
         if self._session:
             return self._session
-        async for session in get_async_db():
-            return session
-        raise RuntimeError("Failed to get database session")
+        # Create a new session for this repository instance
+        self._session = get_async_session()
+        return self._session
 
     async def get_portfolio(
         self,

--- a/packages/data/src/maverick_data/session/__init__.py
+++ b/packages/data/src/maverick_data/session/__init__.py
@@ -7,6 +7,7 @@ Provides session factories and connection management for SQLAlchemy.
 from maverick_data.session.factory import (
     get_db,
     get_async_db,
+    get_async_session,
     get_session,
     init_db,
     close_async_db_connections,
@@ -19,6 +20,7 @@ from maverick_data.session.factory import (
 __all__ = [
     "get_db",
     "get_async_db",
+    "get_async_session",
     "get_session",
     "init_db",
     "close_async_db_connections",

--- a/packages/data/src/maverick_data/session/factory.py
+++ b/packages/data/src/maverick_data/session/factory.py
@@ -250,6 +250,18 @@ def get_session() -> Session:
     return SessionLocal()
 
 
+def get_async_session() -> AsyncSession:
+    """
+    Get async database session (direct session for manual management).
+    
+    The caller is responsible for closing the session when done.
+    Use this for cases where the async generator pattern doesn't work,
+    such as in repository classes that manage their own session lifecycle.
+    """
+    async_session_factory = _get_async_session_factory()
+    return async_session_factory()
+
+
 async def get_async_db() -> AsyncGenerator[AsyncSession, None]:
     """Get an async database session using the cached engine."""
     async_session_factory = _get_async_session_factory()


### PR DESCRIPTION
Fix - SQLAlchemy session management issue by adding a new get_async_session() function and updating the repository to use it.

Root Cause
The PortfolioRepository._get_session() method was using async for session in get_async_db() which breaks the async generator lifecycle - it gets the session but the generator's finally block tries to close it while operations are still in progress.

Fix - Automatic user_id injection for capabilities that require authentication.

Fix - Session lifecycle issue by adding proper cleanup logic to close database sessions after factory-created services are used.

